### PR TITLE
H1 title is now responsive!

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -62,6 +62,12 @@ body {
 
 footer {
     text-align: center;
+    text-shadow: 1px 1px 0 #000, -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000;
     bottom: 0;
     position: absolute;
+}
+
+footer a {
+    color: #e50914;
+    font-size: 1.5rem;
 }

--- a/index.html
+++ b/index.html
@@ -15,13 +15,15 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Quicksand&display=swap" rel="stylesheet">
                 
-    <link rel="stylesheet" href="/assets/style.css">
+    <link rel="stylesheet" href="assets/css/style.css">
     <title>Where The Flick Is It?</title>
 </head>
 
 <body class="container">
     <header>
-        <h1>Where the <span class="flick">FLICK</span> is it?</h1>
+        <div class="container">
+            <h1>Where the <span class="flick">FLICK</span> is it?</h1>
+        </div>
     </header>
     <main>
         <div class="container">


### PR DESCRIPTION
Using containers seems to be the trick with Pico. Adding a container class to a div holding the h1 main page title fixed responsiveness issues from earlier.